### PR TITLE
Make block collision use correct shape instead of box approximation

### DIFF
--- a/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/body/shape/MinecraftShape.java
+++ b/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/body/shape/MinecraftShape.java
@@ -10,6 +10,7 @@ import com.jme3.math.Vector3f;
 import dev.lazurite.rayon.impl.bullet.math.Convert;
 import dev.lazurite.transporter.api.pattern.Pattern;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,10 @@ public sealed interface MinecraftShape permits MinecraftShape.Box, MinecraftShap
 
     static Convex convex(AABB box) {
         return MinecraftShape.convex(Convert.toBullet(box));
+    }
+
+    static Convex convex(VoxelShape voxelShape) {
+        return new Convex(Triangle.getMeshOf(voxelShape));
     }
 
     static Convex convex(BoundingBox box) {


### PR DESCRIPTION
Allows for things like stairs to keep their collision. As a bonus fixes some misaligned collisions (as not all are centered).

![2023-04-19_22 13 31](https://user-images.githubusercontent.com/39821509/233195243-8d8b825a-6228-4228-91ed-fffe4d0dbfef.png)
