### PR TITLE
Make block update bound use speed in box size calculation, to limit collisions not working with too high speeds

### DIFF
--- a/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/body/shape/MinecraftShape.java
+++ b/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/body/shape/MinecraftShape.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-public sealed interface MinecraftShape permits MinecraftShape.Box, MinecraftShape.Convex, MinecraftShape.Concave {
+public interface MinecraftShape {
     List<Triangle> getTriangles(Quaternion quaternion);
     float getVolume();
 

--- a/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/space/cache/SimpleChunkCache.java
+++ b/common/src/main/java/dev/lazurite/rayon/impl/bullet/collision/space/cache/SimpleChunkCache.java
@@ -13,10 +13,9 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.AABB;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,7 +91,7 @@ public class SimpleChunkCache implements ChunkCache {
                 continue;
             }
 
-            final var aabb = rigidBody.getCurrentMinecraftBoundingBox().inflate(1.0f);
+            final var aabb = rigidBody.getCurrentMinecraftBoundingBox().inflate(1.0f + Mth.sqrt(rigidBody.getSquaredSpeed()) / 20);
 
             BlockPos.betweenClosedStream(aabb).forEach(blockPos -> {
                 if (this.activePositions.contains(blockPos.asLong())) {


### PR DESCRIPTION
Should fix collision object passing thorough blocks if they move with speed of over 1 block per tick